### PR TITLE
Chunk long recordings for reliable Gemini verification

### DIFF
--- a/.claude/skills/article-tts-recording.md
+++ b/.claude/skills/article-tts-recording.md
@@ -110,7 +110,7 @@ This sends the audio and source text to Gemini (default model: `gemini-flash-lat
 
 The report opens with a deterministic pre-check (duration, word count, reading pace, unexpected long silences) that costs nothing and catches truncation-class problems. When the article's `[BREAK]` markers line up with the silence gaps in the audio, each section is verified separately and reported under a header like `## Section 2 of 5 (12:34–25:10)` — timestamps inside a section are **relative to that section's start**; add the section's start offset to locate an issue in the full recording.
 
-If the recording is longer than ~20 minutes and its sections can't be paired with the text's `[BREAK]` markers, verification refuses to run (long single-call comparison produces phantom "missing content" reports). Fix the `[BREAK]` structure or regenerate the audio, then re-verify.
+If the recording is longer than ~15 minutes and its sections can't be paired with the text's `[BREAK]` markers, verification refuses to run (long single-call comparison produces phantom "missing content" reports). Fix the `[BREAK]` structure or regenerate the audio, then re-verify.
 
 Cost: ~3 cents per verification of a 16-minute article.
 

--- a/.claude/skills/article-tts-recording.md
+++ b/.claude/skills/article-tts-recording.md
@@ -106,7 +106,11 @@ The `--markdown` flag is auto-detected for `.md` files. It cleans emphasis, head
 uv run python verify_audio.py recording.wav article.md
 ```
 
-This sends the audio and source text to Gemini 2.5 Flash, which listens to the recording and reports mispronunciations, missing/extra content, pacing issues, and audio quality problems — with approximate timestamps.
+This sends the audio and source text to Gemini (default model: `gemini-flash-latest`), which listens to the recording and reports mispronunciations, missing/extra content, pacing issues, and audio quality problems — with approximate timestamps.
+
+The report opens with a deterministic pre-check (duration, word count, reading pace, unexpected long silences) that costs nothing and catches truncation-class problems. When the article's `[BREAK]` markers line up with the silence gaps in the audio, each section is verified separately and reported under a header like `## Section 2 of 5 (12:34–25:10)` — timestamps inside a section are **relative to that section's start**; add the section's start offset to locate an issue in the full recording.
+
+If the recording is longer than ~20 minutes and its sections can't be paired with the text's `[BREAK]` markers, verification refuses to run (long single-call comparison produces phantom "missing content" reports). Fix the `[BREAK]` structure or regenerate the audio, then re-verify.
 
 Cost: ~3 cents per verification of a 16-minute article.
 

--- a/README.md
+++ b/README.md
@@ -123,11 +123,13 @@ uv run python verify_audio.py recording.wav source_text.md
 
 Sends audio + source text to Gemini, which listens and reports mispronunciations, missing or extra content, and pacing issues with timestamps. Costs ~3 cents per 16 minutes of audio.
 
+The report begins with a free, deterministic pre-check (duration, word count, reading pace, unexpected silence gaps) that runs before any model call. When the source text contains `[BREAK]` markers and the audio's silence gaps line up with them, each section is verified separately against its own slice of the text and the results are aggregated under headers like `## Section 2 of 5 (12:34–25:10)` — timestamps inside a section are relative to that section's start. Verifying long recordings in one call produces unreliable phantom reports, so recordings longer than ~20 minutes that can't be chunked this way are rejected with an error asking for `[BREAK]` markers.
+
 | Option | Description | Default |
 |--------|-------------|---------|
 | `audio_file` | Path to the audio file (.wav) | (required) |
 | `text_file` | Path to the source text file | (required) |
-| `--model` | Gemini model to use | `gemini-2.5-flash` |
+| `--model` | Gemini model to use | `gemini-flash-latest` |
 
 Requires a `GEMINI_API_KEY` environment variable or `.env` file.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ uv run python verify_audio.py recording.wav source_text.md
 
 Sends audio + source text to Gemini, which listens and reports mispronunciations, missing or extra content, and pacing issues with timestamps. Costs ~3 cents per 16 minutes of audio.
 
-The report begins with a free, deterministic pre-check (duration, word count, reading pace, unexpected silence gaps) that runs before any model call. When the source text contains `[BREAK]` markers and the audio's silence gaps line up with them, each section is verified separately against its own slice of the text and the results are aggregated under headers like `## Section 2 of 5 (12:34–25:10)` — timestamps inside a section are relative to that section's start. Verifying long recordings in one call produces unreliable phantom reports, so recordings longer than ~20 minutes that can't be chunked this way are rejected with an error asking for `[BREAK]` markers.
+The report begins with a free, deterministic pre-check (duration, word count, reading pace, unexpected silence gaps) that runs before any model call. When the source text contains `[BREAK]` markers and the audio's silence gaps line up with them, each section is verified separately against its own slice of the text and the results are aggregated under headers like `## Section 2 of 5 (12:34–25:10)` — timestamps inside a section are relative to that section's start. Verifying long recordings in one call produces unreliable phantom reports, so recordings longer than ~15 minutes that can't be chunked this way are rejected with an error asking for `[BREAK]` markers.
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -52,7 +52,56 @@ def mock_gemini_client(mock_genai, response_text="No issues found."):
     mock_response = MagicMock()
     mock_response.text = response_text
     mock_client.models.generate_content.return_value = mock_response
+    uploaded = MagicMock()
+    uploaded.state.name = "ACTIVE"
+    mock_client.files.upload.return_value = uploaded
     return mock_client
+
+
+class TestUploadReadiness:
+    """Test that generation waits for the Files API to finish processing.
+
+    files.upload() can return while the file is still PROCESSING; querying
+    the model against such a file makes it behave as if no audio were
+    attached (observed on a 28-minute upload during issue #4 calibration).
+    """
+
+    @patch("verify_audio.time.sleep")
+    @patch("verify_audio.genai")
+    def test_waits_for_processing_upload_to_become_active(
+        self, mock_genai, mock_sleep, tmp_path
+    ):
+        """Test a PROCESSING upload is polled until ACTIVE before generating."""
+        mock_client = mock_gemini_client(mock_genai)
+        uploaded = MagicMock()
+        uploaded.state.name = "PROCESSING"
+        uploaded.name = "files/abc123"
+        mock_client.files.upload.return_value = uploaded
+        ready = MagicMock()
+        ready.state.name = "ACTIVE"
+        still_processing = MagicMock()
+        still_processing.state.name = "PROCESSING"
+        mock_client.files.get.side_effect = [still_processing, ready]
+        audio_path = make_wav(tmp_path / "audio.wav")
+
+        verify_audio(audio_path, "Some text.")
+
+        assert mock_client.files.get.call_count == 2
+        mock_client.models.generate_content.assert_called_once()
+
+    @patch("verify_audio.time.sleep")
+    @patch("verify_audio.genai")
+    def test_failed_upload_raises(self, mock_genai, mock_sleep, tmp_path):
+        """Test a FAILED upload raises instead of querying the model."""
+        mock_client = mock_gemini_client(mock_genai)
+        failed = MagicMock()
+        failed.state.name = "FAILED"
+        mock_client.files.upload.return_value = failed
+        audio_path = make_wav(tmp_path / "audio.wav")
+
+        with pytest.raises(RuntimeError, match="FAILED"):
+            verify_audio(audio_path, "Some text.")
+        mock_client.models.generate_content.assert_not_called()
 
 
 class TestVerifyAudio:

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -151,6 +151,35 @@ class TestCLI:
         call_args = mock_verify.call_args
         assert call_args.kwargs.get("model") == "gemini-flash-latest"
 
+    @patch("verify_audio.verify_audio")
+    def test_cli_unavailable_model_exits_with_clear_error(self, mock_verify, tmp_path, capsys):
+        """Test CLI reports a clear error (not a traceback) when the model 404s."""
+        mock_verify.side_effect = Exception(
+            "404 NOT_FOUND: models/gemini-nonexistent is not found"
+        )
+        audio_path = make_wav(tmp_path / "audio.wav")
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Some text.")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([audio_path, str(text_path), "--model", "gemini-nonexistent"])
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "gemini-nonexistent" in captured.err
+        assert "not available" in captured.err
+
+    @patch("verify_audio.verify_audio")
+    def test_cli_reraises_unrelated_errors(self, mock_verify, tmp_path):
+        """Test CLI doesn't swallow errors that aren't about a missing model."""
+        mock_verify.side_effect = Exception("connection reset by peer")
+        audio_path = make_wav(tmp_path / "audio.wav")
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Some text.")
+
+        with pytest.raises(Exception, match="connection reset"):
+            main([audio_path, str(text_path)])
+
     def test_cli_missing_audio_file_exits(self, tmp_path):
         """Test CLI exits with error for missing audio file."""
         text_path = tmp_path / "source.txt"

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -93,6 +93,16 @@ class TestVerifyAudio:
         call_args = mock_client.models.generate_content.call_args
         assert call_args.kwargs.get("model") == "gemini-2.5-pro" or "gemini-2.5-pro" in str(call_args)
 
+    @patch("verify_audio.genai")
+    def test_default_model_is_maintained_alias(self, mock_genai, tmp_path):
+        """Test that the default model is the maintained gemini-flash-latest alias."""
+        mock_client = mock_gemini_client(mock_genai)
+        audio_path = make_wav(tmp_path / "audio.wav")
+
+        verify_audio(audio_path, "Some text.")
+        call_args = mock_client.models.generate_content.call_args
+        assert call_args.kwargs.get("model") == "gemini-flash-latest"
+
     def test_raises_on_missing_audio_file(self):
         """Test that a missing audio file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
@@ -128,6 +138,18 @@ class TestCLI:
         main([audio_path, str(text_path), "--model", "gemini-2.5-pro"])
         call_args = mock_verify.call_args
         assert call_args.kwargs.get("model") == "gemini-2.5-pro" or call_args[0][2] == "gemini-2.5-pro"
+
+    @patch("verify_audio.verify_audio")
+    def test_cli_default_model_is_maintained_alias(self, mock_verify, tmp_path):
+        """Test CLI defaults to the maintained gemini-flash-latest alias."""
+        mock_verify.return_value = "All good."
+        audio_path = make_wav(tmp_path / "audio.wav")
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Some text.")
+
+        main([audio_path, str(text_path)])
+        call_args = mock_verify.call_args
+        assert call_args.kwargs.get("model") == "gemini-flash-latest"
 
     def test_cli_missing_audio_file_exits(self, tmp_path):
         """Test CLI exits with error for missing audio file."""

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -172,6 +172,23 @@ class TestChunkedVerification:
         assert "## Section 2 of 2 (0:02–0:04)" in result
         assert "relative to" in result  # note explaining in-section timestamps
 
+    @patch("verify_audio.genai")
+    def test_boundary_mismatch_falls_back_to_whole_file_with_warning(
+        self, mock_genai, tmp_path
+    ):
+        """Test gap/section count disagreement warns and verifies whole file."""
+        mock_client = mock_gemini_client(mock_genai)
+        # Two text sections, but audio has no detectable gap
+        audio_path = make_wav(tmp_path / "audio.wav", [("tone", 2000)])
+
+        result = verify_audio(audio_path, self.TWO_SECTION_TEXT)
+
+        assert mock_client.models.generate_content.call_count == 1
+        prompt = str(mock_client.models.generate_content.call_args)
+        assert "Alpha" in prompt and "Beta" in prompt
+        assert "WARNING" in result
+        assert "1 audio chunk" in result and "2 sections" in result
+
 
 class TestFormatTimestamp:
     """Test millisecond-to-MM:SS formatting."""

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -132,7 +132,7 @@ class TestChunkedVerification:
     """Test that [BREAK]-sectioned recordings are verified chunk by chunk."""
 
     TWO_SECTION_TEXT = "Alpha section text.\n\n[BREAK]\n\nBeta section text."
-    TWO_SECTION_SPEC = [("tone", 1000), ("silence", 2000), ("tone", 1000)]
+    TWO_SECTION_SPEC = [("tone", 1000), ("silence", 3200), ("tone", 1000)]
 
     @patch("verify_audio.genai")
     def test_verifies_each_section_against_its_text_slice(self, mock_genai, tmp_path):
@@ -169,7 +169,7 @@ class TestChunkedVerification:
         result = verify_audio(audio_path, self.TWO_SECTION_TEXT)
 
         assert "## Section 1 of 2 (0:00–0:02)" in result
-        assert "## Section 2 of 2 (0:02–0:04)" in result
+        assert "## Section 2 of 2 (0:02–0:05)" in result
         assert "relative to" in result  # note explaining in-section timestamps
 
     @patch("verify_audio.genai")
@@ -250,7 +250,7 @@ class TestSingleCallLimit:
         monkeypatch.setattr("verify_audio.MAX_SINGLE_CALL_MINUTES", 3 / 60)
         audio_path = make_wav(
             tmp_path / "audio.wav",
-            [("tone", 4000), ("silence", 2000), ("tone", 1000)],
+            [("tone", 4000), ("silence", 3200), ("tone", 1000)],
         )
 
         with pytest.raises(ValueError):
@@ -333,8 +333,8 @@ class TestPrecheckReport:
         assert "0:30" in report  # the silence starts 30s in
 
     def test_no_warning_for_normal_break_silence(self):
-        """Test an ordinary ~2s [BREAK] gap does not trigger the silence warning."""
-        audio = make_segment([("tone", 30000), ("silence", 2000), ("tone", 30000)])
+        """Test an ordinary ~3.2s [BREAK] gap does not trigger the silence warning."""
+        audio = make_segment([("tone", 30000), ("silence", 3200), ("tone", 30000)])
         text = " ".join(["word"] * 150)
 
         report = precheck_report(audio, text)
@@ -343,18 +343,30 @@ class TestPrecheckReport:
 
 
 class TestFindSectionGaps:
-    """Test detection of the ~2s silences inserted at [BREAK] boundaries."""
+    """Test detection of the silences at [BREAK] boundaries.
+
+    In real Kokoro output, Kokoro's own trailing quiet at paragraph ends
+    stretches every join: ordinary 300ms joins measure ~1.5-2.0s of
+    silence, [BREAK] joins (2000ms inserted) measure ~3.2-3.4s. Only the
+    latter mark section boundaries.
+    """
 
     def test_finds_break_gap(self):
-        """Test a 2s silence between tones is reported as one gap."""
-        audio = make_segment([("tone", 1000), ("silence", 2000), ("tone", 1000)])
+        """Test a [BREAK]-sized (~3.2s) silence is reported as one gap."""
+        audio = make_segment([("tone", 1000), ("silence", 3200), ("tone", 1000)])
 
         gaps = find_section_gaps(audio)
 
         assert len(gaps) == 1
         start_ms, end_ms = gaps[0]
         assert start_ms == pytest.approx(1000, abs=200)
-        assert end_ms == pytest.approx(3000, abs=200)
+        assert end_ms == pytest.approx(4200, abs=200)
+
+    def test_ignores_paragraph_sized_pauses(self):
+        """Test the ~2s silences at ordinary paragraph joins are not gaps."""
+        audio = make_segment([("tone", 1000), ("silence", 2000), ("tone", 1000)])
+
+        assert find_section_gaps(audio) == []
 
     def test_ignores_short_intra_section_pauses(self):
         """Test the 300ms pauses between ordinary TTS chunks are not gaps."""

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -94,6 +94,18 @@ class TestVerifyAudio:
         assert call_args.kwargs.get("model") == "gemini-2.5-pro" or "gemini-2.5-pro" in str(call_args)
 
     @patch("verify_audio.genai")
+    def test_report_starts_with_precheck(self, mock_genai, tmp_path):
+        """Test the returned report leads with the deterministic pre-check."""
+        mock_gemini_client(mock_genai, "No issues found.")
+        audio_path = make_wav(tmp_path / "audio.wav", [("tone", 4000)])
+
+        result = verify_audio(audio_path, "one two three four five six seven eight nine ten")
+
+        assert result.startswith("## Pre-check")
+        assert "0:04" in result
+        assert "No issues found." in result
+
+    @patch("verify_audio.genai")
     def test_default_model_is_maintained_alias(self, mock_genai, tmp_path):
         """Test that the default model is the maintained gemini-flash-latest alias."""
         mock_client = mock_gemini_client(mock_genai)

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -173,6 +173,20 @@ class TestChunkedVerification:
         assert "relative to" in result  # note explaining in-section timestamps
 
     @patch("verify_audio.genai")
+    def test_single_section_text_verifies_whole_file_without_warning(
+        self, mock_genai, tmp_path
+    ):
+        """Test text without [BREAK] keeps the plain whole-file behavior."""
+        mock_client = mock_gemini_client(mock_genai)
+        audio_path = make_wav(tmp_path / "audio.wav", [("tone", 2000)])
+
+        result = verify_audio(audio_path, "Just one plain section of text.")
+
+        assert mock_client.models.generate_content.call_count == 1
+        assert "could not pair" not in result
+        assert "## Section" not in result
+
+    @patch("verify_audio.genai")
     def test_boundary_mismatch_falls_back_to_whole_file_with_warning(
         self, mock_genai, tmp_path
     ):
@@ -188,6 +202,70 @@ class TestChunkedVerification:
         assert "Alpha" in prompt and "Beta" in prompt
         assert "WARNING" in result
         assert "1 audio chunk" in result and "2 sections" in result
+
+
+class TestSingleCallLimit:
+    """Test that no single model call carries more audio than the threshold.
+
+    Whole-file comparison is only reliable below MAX_SINGLE_CALL_MINUTES
+    (issue #4); beyond it the tool must refuse rather than degrade. Tests
+    shrink the threshold so fixtures stay tiny.
+    """
+
+    TWO_SECTION_TEXT = "Alpha section text.\n\n[BREAK]\n\nBeta section text."
+
+    @patch("verify_audio.genai")
+    def test_long_audio_without_breaks_is_rejected(
+        self, mock_genai, tmp_path, monkeypatch
+    ):
+        """Test single-section text with over-threshold audio raises."""
+        mock_client = mock_gemini_client(mock_genai)
+        monkeypatch.setattr("verify_audio.MAX_SINGLE_CALL_MINUTES", 3 / 60)
+        audio_path = make_wav(tmp_path / "audio.wav", [("tone", 4000)])
+
+        with pytest.raises(ValueError, match="[BREAK]"):
+            verify_audio(audio_path, "No break markers here.")
+        mock_client.models.generate_content.assert_not_called()
+
+    @patch("verify_audio.genai")
+    def test_long_audio_with_mismatched_breaks_is_rejected(
+        self, mock_genai, tmp_path, monkeypatch
+    ):
+        """Test the mismatch fallback also refuses over-threshold audio."""
+        mock_client = mock_gemini_client(mock_genai)
+        monkeypatch.setattr("verify_audio.MAX_SINGLE_CALL_MINUTES", 3 / 60)
+        # Two text sections but no detectable gap: fallback path, too long
+        audio_path = make_wav(tmp_path / "audio.wav", [("tone", 4000)])
+
+        with pytest.raises(ValueError):
+            verify_audio(audio_path, self.TWO_SECTION_TEXT)
+        mock_client.models.generate_content.assert_not_called()
+
+    @patch("verify_audio.genai")
+    def test_oversized_single_chunk_is_rejected(
+        self, mock_genai, tmp_path, monkeypatch
+    ):
+        """Test chunking doesn't help if one section alone exceeds the limit."""
+        mock_client = mock_gemini_client(mock_genai)
+        monkeypatch.setattr("verify_audio.MAX_SINGLE_CALL_MINUTES", 3 / 60)
+        audio_path = make_wav(
+            tmp_path / "audio.wav",
+            [("tone", 4000), ("silence", 2000), ("tone", 1000)],
+        )
+
+        with pytest.raises(ValueError):
+            verify_audio(audio_path, self.TWO_SECTION_TEXT)
+        mock_client.models.generate_content.assert_not_called()
+
+    @patch("verify_audio.genai")
+    def test_short_audio_is_not_rejected(self, mock_genai, tmp_path, monkeypatch):
+        """Test under-threshold whole-file verification still works."""
+        mock_gemini_client(mock_genai)
+        monkeypatch.setattr("verify_audio.MAX_SINGLE_CALL_MINUTES", 3 / 60)
+        audio_path = make_wav(tmp_path / "audio.wav", [("tone", 2000)])
+
+        result = verify_audio(audio_path, "Short enough.")
+        assert "No issues found." in result
 
 
 class TestFormatTimestamp:
@@ -372,6 +450,26 @@ class TestCLI:
         captured = capsys.readouterr()
         assert "gemini-nonexistent" in captured.err
         assert "not available" in captured.err
+
+    @patch("verify_audio.verify_audio")
+    def test_cli_over_threshold_audio_exits_with_clear_error(
+        self, mock_verify, tmp_path, capsys
+    ):
+        """Test the CLI turns the too-long-for-one-call error into exit 1."""
+        mock_verify.side_effect = ValueError(
+            "audio is 28:00 long, but reliable single-call verification "
+            "tops out at ~20 minutes"
+        )
+        audio_path = make_wav(tmp_path / "audio.wav")
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Some text.")
+
+        with pytest.raises(SystemExit) as exc_info:
+            main([audio_path, str(text_path)])
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "28:00" in captured.err
 
     @patch("verify_audio.verify_audio")
     def test_cli_reraises_unrelated_errors(self, mock_verify, tmp_path):

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -10,7 +10,13 @@ from unittest.mock import patch, MagicMock
 from pydub import AudioSegment
 from pydub.generators import Sine
 
-from verify_audio import verify_audio, main, precheck_report, format_timestamp
+from verify_audio import (
+    verify_audio,
+    main,
+    precheck_report,
+    format_timestamp,
+    find_section_gaps,
+)
 
 
 def make_segment(spec):
@@ -193,6 +199,27 @@ class TestPrecheckReport:
         report = precheck_report(audio, text)
 
         assert "WARNING" not in report
+
+
+class TestFindSectionGaps:
+    """Test detection of the ~2s silences inserted at [BREAK] boundaries."""
+
+    def test_finds_break_gap(self):
+        """Test a 2s silence between tones is reported as one gap."""
+        audio = make_segment([("tone", 1000), ("silence", 2000), ("tone", 1000)])
+
+        gaps = find_section_gaps(audio)
+
+        assert len(gaps) == 1
+        start_ms, end_ms = gaps[0]
+        assert start_ms == pytest.approx(1000, abs=200)
+        assert end_ms == pytest.approx(3000, abs=200)
+
+    def test_ignores_short_intra_section_pauses(self):
+        """Test the 300ms pauses between ordinary TTS chunks are not gaps."""
+        audio = make_segment([("tone", 1000), ("silence", 300), ("tone", 1000)])
+
+        assert find_section_gaps(audio) == []
 
 
 class TestCLI:

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -6,96 +6,92 @@ Run with: pytest test_verify_audio.py
 
 import pytest
 from unittest.mock import patch, MagicMock
-import tempfile
-import os
+
+from pydub import AudioSegment
+from pydub.generators import Sine
 
 from verify_audio import verify_audio, main
+
+
+def make_segment(spec):
+    """Build an AudioSegment from a spec like [("tone", 1000), ("silence", 2000)].
+
+    Durations are in milliseconds. Tones are full-scale 440 Hz sine waves,
+    well above any silence-detection threshold.
+    """
+    segment = AudioSegment.empty()
+    for kind, duration_ms in spec:
+        if kind == "tone":
+            piece = Sine(440).to_audio_segment(duration=duration_ms)
+            piece = piece.set_frame_rate(24000).set_channels(1)
+        elif kind == "silence":
+            piece = AudioSegment.silent(duration=duration_ms, frame_rate=24000)
+        else:
+            raise ValueError(f"Unknown spec kind: {kind}")
+        segment += piece
+    return segment
+
+
+def make_wav(path, spec=(("tone", 500),)):
+    """Write a small real WAV file built from a spec. Returns the path as str."""
+    make_segment(spec).export(str(path), format="wav")
+    return str(path)
+
+
+def mock_gemini_client(mock_genai, response_text="No issues found."):
+    """Wire up a mocked genai module and return the mocked client."""
+    mock_client = MagicMock()
+    mock_genai.Client.return_value = mock_client
+    mock_response = MagicMock()
+    mock_response.text = response_text
+    mock_client.models.generate_content.return_value = mock_response
+    return mock_client
 
 
 class TestVerifyAudio:
     """Test the verify_audio function."""
 
     @patch("verify_audio.genai")
-    def test_returns_model_response_text(self, mock_genai):
+    def test_returns_model_response_text(self, mock_genai, tmp_path):
         """Test that verify_audio returns the model's response as a string."""
-        mock_client = MagicMock()
-        mock_genai.Client.return_value = mock_client
-        mock_response = MagicMock()
-        mock_response.text = "No issues found."
-        mock_client.models.generate_content.return_value = mock_response
+        mock_gemini_client(mock_genai, "No issues found.")
+        audio_path = make_wav(tmp_path / "audio.wav")
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(b"fake audio data")
-            audio_path = f.name
-
-        try:
-            result = verify_audio(audio_path, "Some source text.")
-            assert result == "No issues found."
-        finally:
-            os.unlink(audio_path)
+        result = verify_audio(audio_path, "Some source text.")
+        assert "No issues found." in result
 
     @patch("verify_audio.genai")
-    def test_sends_source_text_in_prompt(self, mock_genai):
+    def test_sends_source_text_in_prompt(self, mock_genai, tmp_path):
         """Test that the source text is included in the prompt sent to Gemini."""
-        mock_client = MagicMock()
-        mock_genai.Client.return_value = mock_client
-        mock_response = MagicMock()
-        mock_response.text = "All good."
-        mock_client.models.generate_content.return_value = mock_response
+        mock_client = mock_gemini_client(mock_genai, "All good.")
+        audio_path = make_wav(tmp_path / "audio.wav")
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(b"fake audio data")
-            audio_path = f.name
-
-        try:
-            verify_audio(audio_path, "The quick brown fox.")
-            call_args = mock_client.models.generate_content.call_args
-            # The source text should appear somewhere in the contents sent
-            contents = str(call_args)
-            assert "The quick brown fox." in contents
-        finally:
-            os.unlink(audio_path)
+        verify_audio(audio_path, "The quick brown fox.")
+        call_args = mock_client.models.generate_content.call_args
+        # The source text should appear somewhere in the contents sent
+        contents = str(call_args)
+        assert "The quick brown fox." in contents
 
     @patch("verify_audio.genai")
-    def test_uploads_audio_file(self, mock_genai):
+    def test_uploads_audio_file(self, mock_genai, tmp_path):
         """Test that the audio file is uploaded via the client."""
-        mock_client = MagicMock()
-        mock_genai.Client.return_value = mock_client
-        mock_response = MagicMock()
-        mock_response.text = "All good."
-        mock_client.models.generate_content.return_value = mock_response
+        mock_client = mock_gemini_client(mock_genai, "All good.")
+        audio_path = make_wav(tmp_path / "audio.wav")
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(b"fake audio data")
-            audio_path = f.name
-
-        try:
-            verify_audio(audio_path, "Some text.")
-            mock_client.files.upload.assert_called_once()
-            upload_args = mock_client.files.upload.call_args
-            assert audio_path in str(upload_args)
-        finally:
-            os.unlink(audio_path)
+        verify_audio(audio_path, "Some text.")
+        mock_client.files.upload.assert_called_once()
+        upload_args = mock_client.files.upload.call_args
+        assert audio_path in str(upload_args)
 
     @patch("verify_audio.genai")
-    def test_uses_specified_model(self, mock_genai):
+    def test_uses_specified_model(self, mock_genai, tmp_path):
         """Test that the specified model is passed to generate_content."""
-        mock_client = MagicMock()
-        mock_genai.Client.return_value = mock_client
-        mock_response = MagicMock()
-        mock_response.text = "All good."
-        mock_client.models.generate_content.return_value = mock_response
+        mock_client = mock_gemini_client(mock_genai, "All good.")
+        audio_path = make_wav(tmp_path / "audio.wav")
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            f.write(b"fake audio data")
-            audio_path = f.name
-
-        try:
-            verify_audio(audio_path, "Some text.", model="gemini-2.5-flash")
-            call_args = mock_client.models.generate_content.call_args
-            assert call_args.kwargs.get("model") == "gemini-2.5-flash" or "gemini-2.5-flash" in str(call_args)
-        finally:
-            os.unlink(audio_path)
+        verify_audio(audio_path, "Some text.", model="gemini-2.5-pro")
+        call_args = mock_client.models.generate_content.call_args
+        assert call_args.kwargs.get("model") == "gemini-2.5-pro" or "gemini-2.5-pro" in str(call_args)
 
     def test_raises_on_missing_audio_file(self):
         """Test that a missing audio file raises FileNotFoundError."""
@@ -107,70 +103,43 @@ class TestCLI:
     """Test the command-line interface."""
 
     @patch("verify_audio.verify_audio")
-    def test_cli_with_text_file(self, mock_verify, capsys):
+    def test_cli_with_text_file(self, mock_verify, tmp_path, capsys):
         """Test CLI reads source text from a file."""
         mock_verify.return_value = "No issues found."
+        audio_path = make_wav(tmp_path / "audio.wav")
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Hello world.")
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as af:
-            af.write(b"fake audio")
-            audio_path = af.name
-
-        with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tf:
-            tf.write("Hello world.")
-            text_path = tf.name
-
-        try:
-            main([audio_path, text_path])
-            mock_verify.assert_called_once()
-            args = mock_verify.call_args
-            assert args[0][1] == "Hello world."
-            captured = capsys.readouterr()
-            assert "No issues found." in captured.out
-        finally:
-            os.unlink(audio_path)
-            os.unlink(text_path)
+        main([audio_path, str(text_path)])
+        mock_verify.assert_called_once()
+        args = mock_verify.call_args
+        assert args[0][1] == "Hello world."
+        captured = capsys.readouterr()
+        assert "No issues found." in captured.out
 
     @patch("verify_audio.verify_audio")
-    def test_cli_with_model_flag(self, mock_verify, capsys):
+    def test_cli_with_model_flag(self, mock_verify, tmp_path):
         """Test CLI passes --model flag to verify_audio."""
         mock_verify.return_value = "All good."
+        audio_path = make_wav(tmp_path / "audio.wav")
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Some text.")
 
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as af:
-            af.write(b"fake audio")
-            audio_path = af.name
+        main([audio_path, str(text_path), "--model", "gemini-2.5-pro"])
+        call_args = mock_verify.call_args
+        assert call_args.kwargs.get("model") == "gemini-2.5-pro" or call_args[0][2] == "gemini-2.5-pro"
 
-        with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tf:
-            tf.write("Some text.")
-            text_path = tf.name
-
-        try:
-            main([audio_path, text_path, "--model", "gemini-2.5-pro"])
-            call_args = mock_verify.call_args
-            assert call_args.kwargs.get("model") == "gemini-2.5-pro" or call_args[0][2] == "gemini-2.5-pro"
-        finally:
-            os.unlink(audio_path)
-            os.unlink(text_path)
-
-    def test_cli_missing_audio_file_exits(self, capsys):
+    def test_cli_missing_audio_file_exits(self, tmp_path):
         """Test CLI exits with error for missing audio file."""
-        with tempfile.NamedTemporaryFile(suffix=".txt", mode="w", delete=False) as tf:
-            tf.write("Some text.")
-            text_path = tf.name
+        text_path = tmp_path / "source.txt"
+        text_path.write_text("Some text.")
 
-        try:
-            with pytest.raises(SystemExit):
-                main(["/nonexistent/audio.wav", text_path])
-        finally:
-            os.unlink(text_path)
+        with pytest.raises(SystemExit):
+            main(["/nonexistent/audio.wav", str(text_path)])
 
-    def test_cli_missing_text_file_exits(self):
+    def test_cli_missing_text_file_exits(self, tmp_path):
         """Test CLI exits with error for missing text file."""
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as af:
-            af.write(b"fake audio")
-            audio_path = af.name
+        audio_path = make_wav(tmp_path / "audio.wav")
 
-        try:
-            with pytest.raises(SystemExit):
-                main([audio_path, "/nonexistent/text.txt"])
-        finally:
-            os.unlink(audio_path)
+        with pytest.raises(SystemExit):
+            main([audio_path, "/nonexistent/text.txt"])

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -16,6 +16,7 @@ from verify_audio import (
     precheck_report,
     format_timestamp,
     find_section_gaps,
+    split_audio_at_gaps,
 )
 
 
@@ -220,6 +221,34 @@ class TestFindSectionGaps:
         audio = make_segment([("tone", 1000), ("silence", 300), ("tone", 1000)])
 
         assert find_section_gaps(audio) == []
+
+
+class TestSplitAudioAtGaps:
+    """Test cutting audio into section chunks at detected gaps."""
+
+    def test_splits_at_gap_midpoint(self):
+        """Test one gap yields two chunks cut at its midpoint, with offsets."""
+        audio = make_segment([("tone", 1000), ("silence", 2000), ("tone", 1000)])
+
+        chunks = split_audio_at_gaps(audio, [(1000, 3000)])
+
+        assert len(chunks) == 2
+        (first_start, first_seg), (second_start, second_seg) = chunks
+        assert first_start == 0
+        assert second_start == 2000  # midpoint of the gap
+        assert len(first_seg) == 2000
+        assert len(second_seg) == 2000
+        assert len(first_seg) + len(second_seg) == len(audio)
+
+    def test_no_gaps_returns_whole_audio(self):
+        """Test that with no gaps the audio comes back as a single chunk."""
+        audio = make_segment([("tone", 1000)])
+
+        chunks = split_audio_at_gaps(audio, [])
+
+        assert len(chunks) == 1
+        assert chunks[0][0] == 0
+        assert len(chunks[0][1]) == len(audio)
 
 
 class TestCLI:

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -145,6 +145,24 @@ class TestPrecheckReport:
 
         assert "10 words" in report
 
+    def test_warns_when_pace_is_implausibly_slow(self):
+        """Test a WPM far below speech pace (suggesting missing text) warns."""
+        audio = make_segment([("tone", 60000)])
+        text = " ".join(["word"] * 10)  # 10 WPM
+
+        report = precheck_report(audio, text)
+
+        assert "WARNING" in report
+
+    def test_no_warning_at_normal_speech_pace(self):
+        """Test a normal reading pace produces no warning."""
+        audio = make_segment([("tone", 60000)])
+        text = " ".join(["word"] * 150)  # 150 WPM
+
+        report = precheck_report(audio, text)
+
+        assert "WARNING" not in report
+
 
 class TestCLI:
     """Test the command-line interface."""

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 from pydub import AudioSegment
 from pydub.generators import Sine
 
-from verify_audio import verify_audio, main
+from verify_audio import verify_audio, main, precheck_report, format_timestamp
 
 
 def make_segment(spec):
@@ -107,6 +107,43 @@ class TestVerifyAudio:
         """Test that a missing audio file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
             verify_audio("/nonexistent/audio.wav", "Some text.")
+
+
+class TestFormatTimestamp:
+    """Test millisecond-to-MM:SS formatting."""
+
+    def test_formats_minutes_and_seconds(self):
+        assert format_timestamp(754000) == "12:34"
+
+    def test_pads_seconds(self):
+        assert format_timestamp(4000) == "0:04"
+
+    def test_formats_over_an_hour(self):
+        assert format_timestamp(3723000) == "62:03"
+
+
+class TestPrecheckReport:
+    """Test the deterministic pre-check that runs before any model call."""
+
+    def test_reports_duration_word_count_and_pace(self):
+        """Test the report includes duration, word count, and words per minute."""
+        audio = make_segment([("tone", 4000)])
+        text = "one two three four five six seven eight nine ten"
+
+        report = precheck_report(audio, text)
+
+        assert "0:04" in report
+        assert "10 words" in report
+        assert "150" in report  # 10 words / 4s = 150 WPM
+
+    def test_break_markers_not_counted_as_words(self):
+        """Test [BREAK] markers are excluded from the word count."""
+        audio = make_segment([("tone", 4000)])
+        text = "one two three four five\n[BREAK]\nsix seven eight nine ten"
+
+        report = precheck_report(audio, text)
+
+        assert "10 words" in report
 
 
 class TestCLI:

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -163,6 +163,25 @@ class TestPrecheckReport:
 
         assert "WARNING" not in report
 
+    def test_warns_on_unexpectedly_long_silence(self):
+        """Test a silence gap far longer than a [BREAK] pause warns with a timestamp."""
+        audio = make_segment([("tone", 30000), ("silence", 6000), ("tone", 30000)])
+        text = " ".join(["word"] * 150)  # pace in band; only silence should warn
+
+        report = precheck_report(audio, text)
+
+        assert "WARNING" in report
+        assert "0:30" in report  # the silence starts 30s in
+
+    def test_no_warning_for_normal_break_silence(self):
+        """Test an ordinary ~2s [BREAK] gap does not trigger the silence warning."""
+        audio = make_segment([("tone", 30000), ("silence", 2000), ("tone", 30000)])
+        text = " ".join(["word"] * 150)
+
+        report = precheck_report(audio, text)
+
+        assert "WARNING" not in report
+
 
 class TestCLI:
     """Test the command-line interface."""

--- a/tests/test_verify_audio.py
+++ b/tests/test_verify_audio.py
@@ -128,6 +128,51 @@ class TestVerifyAudio:
             verify_audio("/nonexistent/audio.wav", "Some text.")
 
 
+class TestChunkedVerification:
+    """Test that [BREAK]-sectioned recordings are verified chunk by chunk."""
+
+    TWO_SECTION_TEXT = "Alpha section text.\n\n[BREAK]\n\nBeta section text."
+    TWO_SECTION_SPEC = [("tone", 1000), ("silence", 2000), ("tone", 1000)]
+
+    @patch("verify_audio.genai")
+    def test_verifies_each_section_against_its_text_slice(self, mock_genai, tmp_path):
+        """Test each audio chunk is sent with only its own section's text."""
+        mock_client = mock_gemini_client(mock_genai)
+        audio_path = make_wav(tmp_path / "audio.wav", self.TWO_SECTION_SPEC)
+
+        verify_audio(audio_path, self.TWO_SECTION_TEXT)
+
+        assert mock_client.files.upload.call_count == 2
+        assert mock_client.models.generate_content.call_count == 2
+        first_prompt = str(mock_client.models.generate_content.call_args_list[0])
+        second_prompt = str(mock_client.models.generate_content.call_args_list[1])
+        assert "Alpha" in first_prompt and "Beta" not in first_prompt
+        assert "Beta" in second_prompt and "Alpha" not in second_prompt
+
+    @patch("verify_audio.genai")
+    def test_chunk_prompts_include_section_context(self, mock_genai, tmp_path):
+        """Test each chunk's prompt says which section of how many it is."""
+        mock_client = mock_gemini_client(mock_genai)
+        audio_path = make_wav(tmp_path / "audio.wav", self.TWO_SECTION_SPEC)
+
+        verify_audio(audio_path, self.TWO_SECTION_TEXT)
+
+        first_prompt = str(mock_client.models.generate_content.call_args_list[0])
+        assert "section 1 of 2" in first_prompt
+
+    @patch("verify_audio.genai")
+    def test_report_has_section_headers_with_absolute_ranges(self, mock_genai, tmp_path):
+        """Test the aggregated report labels each section with its time range."""
+        mock_gemini_client(mock_genai, "No issues found.")
+        audio_path = make_wav(tmp_path / "audio.wav", self.TWO_SECTION_SPEC)
+
+        result = verify_audio(audio_path, self.TWO_SECTION_TEXT)
+
+        assert "## Section 1 of 2 (0:00–0:02)" in result
+        assert "## Section 2 of 2 (0:02–0:04)" in result
+        assert "relative to" in result  # note explaining in-section timestamps
+
+
 class TestFormatTimestamp:
     """Test millisecond-to-MM:SS formatting."""
 

--- a/text_to_speech.py
+++ b/text_to_speech.py
@@ -15,7 +15,15 @@ from typing import List
 import numpy as np
 import soundfile as sf
 from pydub import AudioSegment
-from mlx_audio.tts.utils import load_model
+
+try:
+    # mlx_audio only imports on Apple Silicon (it pulls in libmlx). Guard it so
+    # dependency-free helpers here (e.g. split_sections) can be imported by
+    # tools like verify_audio.py on any platform. The name stays bound for
+    # generate_audio and for tests that patch text_to_speech.load_model.
+    from mlx_audio.tts.utils import load_model
+except ImportError:  # pragma: no cover - exercised only off Apple Silicon
+    load_model = None
 
 
 def read_text_file(file_path: str) -> str:
@@ -112,6 +120,10 @@ def generate_audio(
 
     sections = split_sections(text)
 
+    if load_model is None:
+        raise RuntimeError(
+            "mlx_audio is unavailable (audio generation requires Apple Silicon)."
+        )
     model = load_model("mlx-community/Kokoro-82M-bf16")
 
     temp_dir = tempfile.mkdtemp(prefix="kokoro_tts_")

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -14,6 +14,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+DEFAULT_MODEL = "gemini-flash-latest"
+
 VERIFICATION_PROMPT = """Here is the source text of an article, and an audio recording of it being read aloud. Compare them carefully. Report:
 
 - Words that are mispronounced or garbled
@@ -30,7 +32,7 @@ SOURCE TEXT:
 {source_text}"""
 
 
-def verify_audio(audio_path: str, source_text: str, model: str = "gemini-2.5-flash") -> str:
+def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:
     """Verify a TTS audio recording against its source text using Gemini.
 
     Args:
@@ -69,8 +71,8 @@ def main(argv=None):
     parser.add_argument("audio_file", help="Path to the audio file (.wav)")
     parser.add_argument("text_file", help="Path to the source text file")
     parser.add_argument(
-        "--model", default="gemini-2.5-flash",
-        help="Gemini model to use (default: gemini-2.5-flash)"
+        "--model", default=DEFAULT_MODEL,
+        help=f"Gemini model to use (default: {DEFAULT_MODEL})"
     )
 
     args = parser.parse_args(argv)

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -82,14 +82,17 @@ def precheck_report(audio: AudioSegment, source_text: str) -> str:
 
 def find_section_gaps(
     audio: AudioSegment,
-    min_silence_len: int = 1500,
+    min_silence_len: int = 2500,
     silence_thresh: int = -40,
 ) -> list:
     """Find the silence gaps inserted at [BREAK] section boundaries.
 
     text_to_speech.py inserts 2000ms of silence at each [BREAK] and only
-    300ms between ordinary chunks, so a 1500ms minimum cleanly separates
-    the two. Returns a list of (start_ms, end_ms) tuples.
+    300ms between ordinary chunks — but Kokoro's own trailing quiet at
+    paragraph ends stretches both: in real recordings ordinary joins
+    measure ~1.5-2.0s of silence and [BREAK] joins ~3.2-3.4s. A 2500ms
+    minimum separates the two populations. Returns a list of
+    (start_ms, end_ms) tuples.
     """
     return [
         (start_ms, end_ms)

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -62,7 +62,7 @@ def precheck_report(audio: AudioSegment, source_text: str) -> str:
             "range (100-250) — audio may be truncated or have extra content."
         )
     for start_ms, end_ms in detect_silence(
-        audio, min_silence_len=5000, silence_thresh=-40
+        audio, min_silence_len=5000, silence_thresh=-40, seek_step=100
     ):
         lines.append(
             f"WARNING: {format_timestamp(end_ms - start_ms)} of silence at "

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -86,7 +86,17 @@ def main(argv=None):
         sys.exit(1)
 
     source_text = Path(args.text_file).read_text()
-    result = verify_audio(args.audio_file, source_text, model=args.model)
+    try:
+        result = verify_audio(args.audio_file, source_text, model=args.model)
+    except Exception as e:
+        if "404" in str(e) or "NOT_FOUND" in str(e):
+            print(
+                f"Error: model '{args.model}' is not available — "
+                f"try --model {DEFAULT_MODEL}. ({e})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        raise
     print(result)
 
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -141,6 +141,13 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
         report = _verify_chunked(client, audio, sections, gaps, model)
     else:
         report = _verify_single(client, audio_path, source_text, model)
+        if len(sections) > 1:
+            report = (
+                f"WARNING: audio has {len(gaps) + 1} audio chunk(s) at "
+                f"[BREAK]-style silence gaps but the text has {len(sections)} "
+                "sections — could not pair them, so the whole file was "
+                f"verified in one call.\n\n{report}"
+            )
 
     return f"{precheck}\n\n{report}"
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -144,16 +144,23 @@ def check_single_call_limit(duration_ms: int, description: str) -> None:
 def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:
     """Verify a TTS audio recording against its source text using Gemini.
 
+    Runs a deterministic pre-check, then — when the audio's [BREAK]
+    silence gaps pair up with the text's [BREAK] sections — verifies each
+    section separately and aggregates the results. Otherwise verifies the
+    whole file in one call, provided it's short enough to be reliable.
+
     Args:
         audio_path: Path to the audio file (.wav)
         source_text: The original text that was read aloud
         model: Gemini model to use for verification
 
     Returns:
-        The model's assessment as a string
+        The pre-check stats followed by the model's assessment
 
     Raises:
         FileNotFoundError: If the audio file doesn't exist
+        ValueError: If a single call would need more audio than
+            MAX_SINGLE_CALL_MINUTES allows
     """
     if not os.path.exists(audio_path):
         raise FileNotFoundError(f"Audio file not found: {audio_path}")

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from google import genai
 from dotenv import load_dotenv
 from pydub import AudioSegment
+from pydub.silence import detect_silence
 
 load_dotenv()
 
@@ -59,6 +60,13 @@ def precheck_report(audio: AudioSegment, source_text: str) -> str:
         lines.append(
             f"WARNING: pace of {wpm:.0f} WPM is outside the normal speech "
             "range (100-250) — audio may be truncated or have extra content."
+        )
+    for start_ms, end_ms in detect_silence(
+        audio, min_silence_len=5000, silence_thresh=-40
+    ):
+        lines.append(
+            f"WARNING: {format_timestamp(end_ms - start_ms)} of silence at "
+            f"{format_timestamp(start_ms)} — far longer than a [BREAK] pause."
         )
     return "\n".join(lines)
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -189,14 +189,24 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
     return f"{precheck}\n\n{report}"
 
 
-def _wait_until_active(client, audio_file, poll_seconds: int = 2):
+def _wait_until_active(client, audio_file, poll_seconds: int = 2,
+                       timeout_seconds: int = 300):
     """Block until an uploaded file finishes processing.
 
     files.upload() can return while the file is still PROCESSING; querying
-    the model against it then behaves as if no audio were attached.
+    the model against it then behaves as if no audio were attached. Gives
+    up after timeout_seconds so a file wedged in PROCESSING can't hang the
+    tool indefinitely.
     """
+    waited = 0
     while audio_file.state.name == "PROCESSING":
+        if waited >= timeout_seconds:
+            raise RuntimeError(
+                f"Uploaded audio file still PROCESSING after "
+                f"{timeout_seconds}s — giving up."
+            )
         time.sleep(poll_seconds)
+        waited += poll_seconds
         audio_file = client.files.get(name=audio_file.name)
     if audio_file.state.name != "ACTIVE":
         raise RuntimeError(
@@ -214,10 +224,18 @@ def _verify_single(client, audio_path: str, source_text: str, model: str,
     if context_note:
         prompt = f"{context_note}\n\n{prompt}"
 
-    response = client.models.generate_content(
-        model=model,
-        contents=[prompt, audio_file],
-    )
+    try:
+        response = client.models.generate_content(
+            model=model,
+            contents=[prompt, audio_file],
+        )
+    finally:
+        # Best-effort cleanup so chunked runs don't pile uploads up against
+        # the Files API quota (uploads otherwise linger ~48h).
+        try:
+            client.files.delete(name=audio_file.name)
+        except Exception:
+            pass
 
     return response.text
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -9,11 +9,14 @@ import argparse
 import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 from google import genai
 from dotenv import load_dotenv
 from pydub import AudioSegment
 from pydub.silence import detect_silence
+
+from text_to_speech import split_sections
 
 load_dotenv()
 
@@ -131,16 +134,67 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
 
     client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
 
+    sections = split_sections(source_text)
+    gaps = find_section_gaps(audio)
+
+    if len(sections) > 1 and len(gaps) + 1 == len(sections):
+        report = _verify_chunked(client, audio, sections, gaps, model)
+    else:
+        report = _verify_single(client, audio_path, source_text, model)
+
+    return f"{precheck}\n\n{report}"
+
+
+def _verify_single(client, audio_path: str, source_text: str, model: str,
+                   context_note: str = "") -> str:
+    """Verify one audio file against its text in a single model call."""
     audio_file = client.files.upload(file=audio_path)
 
     prompt = VERIFICATION_PROMPT.format(source_text=source_text)
+    if context_note:
+        prompt = f"{context_note}\n\n{prompt}"
 
     response = client.models.generate_content(
         model=model,
         contents=[prompt, audio_file],
     )
 
-    return f"{precheck}\n\n{response.text}"
+    return response.text
+
+
+def _verify_chunked(client, audio: AudioSegment, sections: list,
+                    gaps: list, model: str) -> str:
+    """Verify each [BREAK] section separately and aggregate the results."""
+    chunks = split_audio_at_gaps(audio, gaps)
+    total = len(chunks)
+    parts = [
+        "Note: timestamps within each section below are relative to that "
+        "section's start; the header gives its absolute range."
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="verify_audio_") as temp_dir:
+        for i, ((start_ms, segment), section_text) in enumerate(
+            zip(chunks, sections), start=1
+        ):
+            chunk_path = os.path.join(temp_dir, f"section_{i}.wav")
+            segment.export(chunk_path, format="wav")
+
+            context_note = (
+                f"This audio is section {i} of {total} of a longer recording; "
+                "it may begin and end mid-article."
+            )
+            result = _verify_single(
+                client, chunk_path, section_text, model, context_note
+            )
+
+            end_ms = start_ms + len(segment)
+            header = (
+                f"## Section {i} of {total} "
+                f"({format_timestamp(start_ms)}–{format_timestamp(end_ms)})"
+            )
+            parts.append(f"{header}\n{result}")
+
+    return "\n\n".join(parts)
 
 
 def main(argv=None):

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -24,10 +24,13 @@ load_dotenv()
 DEFAULT_MODEL = "gemini-flash-latest"
 
 # Longest stretch of audio one generate_content call can be trusted with.
-# Beyond this, whole-file comparison starts producing phantom
-# missing-content reports (issue #4): ~16 minutes was reliable, ~28 was
-# not. Calibrated empirically; see the issue for the methodology.
-MAX_SINGLE_CALL_MINUTES = 20
+# Calibrated empirically on known audio (issue #4): at 11.4 minutes,
+# repeated runs were consistent and caught a real mispronunciation every
+# time; at 17.5 minutes, 1 in 4 runs reported phantom missing content
+# and all 4 missed that same real issue; at 28 minutes phantoms were
+# reproducible. 15 sits above every real [BREAK] section (max 13.5 min)
+# and below the shortest length where comparison degraded.
+MAX_SINGLE_CALL_MINUTES = 15
 
 VERIFICATION_PROMPT = """Here is the source text of an article, and an audio recording of it being read aloud. Compare them carefully. Report:
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -50,11 +50,17 @@ def precheck_report(audio: AudioSegment, source_text: str) -> str:
     word_count = len(re.sub(r"\[BREAK\]", " ", source_text).split())
     wpm = word_count / (duration_ms / 60000) if duration_ms else 0
 
-    return (
-        "## Pre-check (deterministic)\n"
+    lines = [
+        "## Pre-check (deterministic)",
         f"Duration: {format_timestamp(duration_ms)} | "
-        f"{word_count} words | {wpm:.0f} WPM"
-    )
+        f"{word_count} words | {wpm:.0f} WPM",
+    ]
+    if not 100 <= wpm <= 250:
+        lines.append(
+            f"WARNING: pace of {wpm:.0f} WPM is outside the normal speech "
+            "range (100-250) — audio may be truncated or have extra content."
+        )
+    return "\n".join(lines)
 
 
 def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -7,10 +7,12 @@ mispronunciations, missing content, and other issues.
 
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 from google import genai
 from dotenv import load_dotenv
+from pydub import AudioSegment
 
 load_dotenv()
 
@@ -30,6 +32,29 @@ If the recording is faithful to the source text with no issues, say "No issues f
 
 SOURCE TEXT:
 {source_text}"""
+
+
+def format_timestamp(ms: int) -> str:
+    """Format a millisecond offset as M:SS (e.g. 754000 -> "12:34")."""
+    total_seconds = int(ms // 1000)
+    return f"{total_seconds // 60}:{total_seconds % 60:02d}"
+
+
+def precheck_report(audio: AudioSegment, source_text: str) -> str:
+    """Deterministic sanity checks that run before any model call.
+
+    Reports audio duration, source word count, and effective words per
+    minute. Costs nothing — no API call involved.
+    """
+    duration_ms = len(audio)
+    word_count = len(re.sub(r"\[BREAK\]", " ", source_text).split())
+    wpm = word_count / (duration_ms / 60000) if duration_ms else 0
+
+    return (
+        "## Pre-check (deterministic)\n"
+        f"Duration: {format_timestamp(duration_ms)} | "
+        f"{word_count} words | {wpm:.0f} WPM"
+    )
 
 
 def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -10,6 +10,7 @@ import os
 import re
 import sys
 import tempfile
+import time
 from pathlib import Path
 from google import genai
 from dotenv import load_dotenv
@@ -178,10 +179,26 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
     return f"{precheck}\n\n{report}"
 
 
+def _wait_until_active(client, audio_file, poll_seconds: int = 2):
+    """Block until an uploaded file finishes processing.
+
+    files.upload() can return while the file is still PROCESSING; querying
+    the model against it then behaves as if no audio were attached.
+    """
+    while audio_file.state.name == "PROCESSING":
+        time.sleep(poll_seconds)
+        audio_file = client.files.get(name=audio_file.name)
+    if audio_file.state.name != "ACTIVE":
+        raise RuntimeError(
+            f"Uploaded audio file ended in state {audio_file.state.name}"
+        )
+    return audio_file
+
+
 def _verify_single(client, audio_path: str, source_text: str, model: str,
                    context_note: str = "") -> str:
     """Verify one audio file against its text in a single model call."""
-    audio_file = client.files.upload(file=audio_path)
+    audio_file = _wait_until_active(client, client.files.upload(file=audio_path))
 
     prompt = VERIFICATION_PROMPT.format(source_text=source_text)
     if context_note:

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -93,6 +93,22 @@ def find_section_gaps(
     ]
 
 
+def split_audio_at_gaps(audio: AudioSegment, gaps: list) -> list:
+    """Cut audio into section chunks at the midpoint of each gap.
+
+    Returns a list of (start_ms, segment) tuples where start_ms is the
+    chunk's absolute offset in the full recording. Cutting mid-gap keeps
+    ~1s of silence padding on each side of the cut.
+    """
+    cut_points = [(start_ms + end_ms) // 2 for start_ms, end_ms in gaps]
+    chunks = []
+    previous_cut = 0
+    for cut in cut_points + [len(audio)]:
+        chunks.append((previous_cut, audio[previous_cut:cut]))
+        previous_cut = cut
+    return chunks
+
+
 def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:
     """Verify a TTS audio recording against its source text using Gemini.
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -88,6 +88,9 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
     if not os.path.exists(audio_path):
         raise FileNotFoundError(f"Audio file not found: {audio_path}")
 
+    audio = AudioSegment.from_wav(audio_path)
+    precheck = precheck_report(audio, source_text)
+
     client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
 
     audio_file = client.files.upload(file=audio_path)
@@ -99,7 +102,7 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
         contents=[prompt, audio_file],
     )
 
-    return response.text
+    return f"{precheck}\n\n{response.text}"
 
 
 def main(argv=None):

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -71,6 +71,28 @@ def precheck_report(audio: AudioSegment, source_text: str) -> str:
     return "\n".join(lines)
 
 
+def find_section_gaps(
+    audio: AudioSegment,
+    min_silence_len: int = 1500,
+    silence_thresh: int = -40,
+) -> list:
+    """Find the silence gaps inserted at [BREAK] section boundaries.
+
+    text_to_speech.py inserts 2000ms of silence at each [BREAK] and only
+    300ms between ordinary chunks, so a 1500ms minimum cleanly separates
+    the two. Returns a list of (start_ms, end_ms) tuples.
+    """
+    return [
+        (start_ms, end_ms)
+        for start_ms, end_ms in detect_silence(
+            audio,
+            min_silence_len=min_silence_len,
+            silence_thresh=silence_thresh,
+            seek_step=50,
+        )
+    ]
+
+
 def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:
     """Verify a TTS audio recording against its source text using Gemini.
 

--- a/verify_audio.py
+++ b/verify_audio.py
@@ -22,6 +22,12 @@ load_dotenv()
 
 DEFAULT_MODEL = "gemini-flash-latest"
 
+# Longest stretch of audio one generate_content call can be trusted with.
+# Beyond this, whole-file comparison starts producing phantom
+# missing-content reports (issue #4): ~16 minutes was reliable, ~28 was
+# not. Calibrated empirically; see the issue for the methodology.
+MAX_SINGLE_CALL_MINUTES = 20
+
 VERIFICATION_PROMPT = """Here is the source text of an article, and an audio recording of it being read aloud. Compare them carefully. Report:
 
 - Words that are mispronounced or garbled
@@ -112,6 +118,22 @@ def split_audio_at_gaps(audio: AudioSegment, gaps: list) -> list:
     return chunks
 
 
+def check_single_call_limit(duration_ms: int, description: str) -> None:
+    """Refuse to send more audio in one model call than is reliable.
+
+    Raises ValueError with remediation guidance when duration_ms exceeds
+    MAX_SINGLE_CALL_MINUTES.
+    """
+    if duration_ms > MAX_SINGLE_CALL_MINUTES * 60000:
+        raise ValueError(
+            f"{description} is {format_timestamp(duration_ms)} long, but "
+            "reliable single-call verification tops out at "
+            f"~{MAX_SINGLE_CALL_MINUTES:g} minutes — beyond that Gemini "
+            "reports phantom discrepancies. Add [BREAK] markers to the "
+            "text and regenerate the audio so verification can be chunked."
+        )
+
+
 def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) -> str:
     """Verify a TTS audio recording against its source text using Gemini.
 
@@ -140,6 +162,7 @@ def verify_audio(audio_path: str, source_text: str, model: str = DEFAULT_MODEL) 
     if len(sections) > 1 and len(gaps) + 1 == len(sections):
         report = _verify_chunked(client, audio, sections, gaps, model)
     else:
+        check_single_call_limit(len(audio), "This audio")
         report = _verify_single(client, audio_path, source_text, model)
         if len(sections) > 1:
             report = (
@@ -174,6 +197,8 @@ def _verify_chunked(client, audio: AudioSegment, sections: list,
     """Verify each [BREAK] section separately and aggregate the results."""
     chunks = split_audio_at_gaps(audio, gaps)
     total = len(chunks)
+    for i, (_, segment) in enumerate(chunks, start=1):
+        check_single_call_limit(len(segment), f"Section {i} of {total}")
     parts = [
         "Note: timestamps within each section below are relative to that "
         "section's start; the header gives its absolute range."
@@ -229,6 +254,9 @@ def main(argv=None):
     source_text = Path(args.text_file).read_text()
     try:
         result = verify_audio(args.audio_file, source_text, model=args.model)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
         if "404" in str(e) or "NOT_FOUND" in str(e):
             print(


### PR DESCRIPTION
## Summary

Closes #4.

- **Chunked verification**: `verify_audio.py` now detects the silence gaps at `[BREAK]` boundaries (2500ms minimum, calibrated against real Kokoro output), cuts the audio at gap midpoints, verifies each section against only its own text slice, and aggregates results under headers with absolute time ranges (`## Section 2 of 8 (11:24–17:31)`).
- **Deterministic pre-check**: every report leads with free stats — duration, word count, WPM (warning outside 100–250), and any silence ≥5s — before any model call.
- **Hard single-call limit**: `MAX_SINGLE_CALL_MINUTES = 15`, calibrated empirically (11.4 min consistent and caught a real mispronunciation every run; 17.5 min produced phantoms and missed that same real issue 4/4 runs). Unpairable audio over the limit is rejected with remediation guidance instead of silently degrading.
- **Upload-readiness fix**: polls the Files API until uploads are `ACTIVE` — a still-`PROCESSING` file makes Gemini respond as if no audio were attached (observed on a 28-minute upload; likely a contributor to the original phantom reports).
- **Model default**: `gemini-2.5-flash` (deprecated) → `gemini-flash-latest`; unavailable models now produce a one-line error and exit 1 instead of a traceback.

Built with red/green TDD; test suite grew from 94 to 125 tests.

## Test plan

- [x] `uv run pytest` — 125 passed
- [x] Two full chunked runs on the 70-minute "Offloading Ourselves" recording: stable results, real mispronunciations reproduced at identical timestamps, no phantom missing-content failures
- [x] Phantom claims fact-checked via targeted clip transcription
- [x] Failure paths exercised end-to-end: over-limit unpairable audio → clear error, exit 1; bogus model → one-line error, exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)